### PR TITLE
fix(ci): Update path to dev Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
 
   - package-ecosystem: "docker"
     # Look for a `Dockerfile` in the directory
-    directory: "/.devcontainer/"
+    directory: "/docker/"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
There was an old path in the dependabot config