### PR TITLE
Fix(devcontainer): Simplify the setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,10 @@
 {
 	"name": "Infrastructure management tools development",
 
-	"dockerComposeFile": ["../docker/docker-compose.testing.yml", "docker-compose.extend.yml"],
+	"dockerComposeFile": ["docker-compose.extend.yml"],
 
 	"service": "cli-app",
-	"workspaceFolder": "/workspace",
+	"workspaceFolder": "/app",
 	"shutdownAction": "stopCompose",
 
 	// Set *default* container specific settings.json values on container create.

--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -6,9 +6,9 @@ services:
       context: ..
       dockerfile: ./docker/Dockerfile.dev
     volumes:
-      # Mounts the project folder to '/workspace'. While this file is in .devcontainer,
+      # Mounts the project folder to '/app'. While this file is in .devcontainer,
       # mounts are relative to the first file in the list, which is a level up.
-      - ..:/workspace:cached
+      - ..:/app:cached
 
     # [Optional] Required for ptrace-based debuggers like C++, Go, and Rust
     # cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3"
 
 services:
   cli-app:


### PR DESCRIPTION
The devcontainer docker compose file does not need to extend the testing
compose file, as it is redifining all contents anyway. Also the sources
bind mount should be called the same in the whole project.